### PR TITLE
Add explicit untwist isomorphism ψ to Section 4.x and Appendix B note (#77)

### DIFF
--- a/draft-irtf-cfrg-pairing-friendly-curves.md
+++ b/draft-irtf-cfrg-pairing-friendly-curves.md
@@ -1,6 +1,6 @@
 ---
 title: "Pairing-Friendly Curves"
-docname: draft-irtf-cfrg-pairing-friendly-curves-latest
+docname: draft-irtf-cfrg-pairing-friendly-curves-13
 category: info
 ipr: trust200902
 area: IRTF
@@ -168,7 +168,7 @@ A pairing e is defined by taking G_1 as a subgroup of E(GF(p)) of order r, G_2 a
 
 ## Barreto-Lynn-Scott Curves  {#BLSdef}
 
-A BLS curve {{BLS02}} is a another family of pairing-frinedly curves proposed in 2002. Similar to BN curves, a pairing over BLS curves constructs optimal Ate pairings.
+A BLS curve {{BLS02}} is another family of pairing-friendly curves proposed in 2002. Similar to BN curves, a pairing over BLS curves constructs optimal Ate pairings.
 
 A BLS curve is defined by elliptic curves E and E' parameterized by a well-chosen integer t. E is defined over a finite field GF(p) by an equation of the form E: y^2 = x^3 + b, and its twist E': y^2 = x^3 + b', is defined in the same way as BN curves. In contrast to BN curves, E(GF(p)) does not have a prime order. Instead, its order is divisible by a large parameterized prime r and denoted by h * r with cofactor h. The pairing is defined on the r-torsion points. In the same way as BN curves, BLS curves can be categorized as D-type and M-type.
 
@@ -333,6 +333,16 @@ For the finite field GF(p), the towers of extension field GF(p^2), GF(p^6) and G
 
 Defined by t, the elliptic curve E and its twist E' are represented by E: y^2 = x^3 + 4 and E': y^2 = x^3 + 4(u + 1). BLS12_381 is categorized as M-type.
 
+The untwist isomorphism ψ : E'(GF(p^2)) → E(GF(p^12)) is given by
+
+~~~~~~~~~~
+
+    ψ(x', y') = (x' / w^2, y' / w^3)
+
+~~~~~~~~~~
+
+where w^2 = v ∈ GF(p^6) and v^3 = u + 1, per the tower defined in {{tower_bls12_381}}.
+
 We have to note that the security level of this pairing is expected to be 126 rather than 128 bits {{GMT19}}.
 
 Parameters of BLS12_381 are given as follows.
@@ -403,6 +413,16 @@ For the finite field GF(p), the towers of extension field GF(p^2), GF(p^6) and G
 ~~~~~~~~~~
 
 Defined by t, the elliptic curve E and its twist E' are represented by E: y^2 = x^3 + 5 and E': y^2 = x^3 - u + 2, respectively. The size of p becomes 462-bit length. BN462 is categorized as D-type.
+
+The untwist isomorphism ψ : E'(GF(p^2)) → E(GF(p^12)) is given by
+
+~~~~~~~~~~
+
+    ψ(x', y') = (x' · w^2, y' · w^3)
+
+~~~~~~~~~~
+
+where w^2 = v ∈ GF(p^6) and v^3 = u + 2, per the tower defined in {{tower_bn462}}.
 
 We have to note that BN462 is significantly slower than BLS12_381, but has 134-bit security level {{GMT19}}, so may be more resistant to future small improvements to the exTNFS attack.
 
@@ -476,6 +496,16 @@ For the finite field GF(p), the towers of extension field GF(p^2), GF(p^4), GF(p
 ~~~~~~~~~~
 
 The elliptic curve E and its twist E' are represented by E: y^2 = x^3 + 1 and E': y^2 = x^3 - 1 / w. BLS48_581 is categorized as D-type.
+
+The untwist isomorphism ψ : E'(GF(p^8)) → E(GF(p^48)) is given by
+
+~~~~~~~~~~
+
+    ψ(x', y') = (x' · ξ^2, y' · ξ^3)
+
+~~~~~~~~~~
+
+where ξ = u · s ∈ GF(p^48) satisfies ξ^6 = -w (the twist coefficient), per the tower defined in {{tower_bls48_581}}. Concretely: u ∈ GF(p^2) satisfies u^2 = -1, so u^6 = -1; s ∈ GF(p^48) satisfies s^2 = -z and z^3 = -w, so s^6 = w; hence ξ^6 = u^6 · s^6 = (-1) · w = -w.
 
 We then give the parameters for BLS48_581 as follows.
 
@@ -1569,6 +1599,8 @@ The following algorithm shows the computation of the optimal Ate pairing on Barr
 # Test Vectors of Optimal Ate Pairing  {#test-vectors-of-optimal-ate-pairing}
 
 We provide test vectors for Optimal Ate Pairing e(P, Q) given in {{comp_pairing}} for the curves BLS12_381, BN462 and BLS48_581 given in {{secure_params}}. Here, the inputs P = (x, y) and Q = (x', y') are the corresponding base points BP and BP' given in {{secure_params}}.
+
+Note: The G_2 base points Q = (x', y') in this appendix are given in twisted form, i.e., as coordinates over E'(GF(p^(k/d))), which gives a compact representation. The pseudocode in Appendix A operates on points of the untwisted curve E(GF(p^k)). Implementations invoking that pseudocode directly must first apply the untwist isomorphism ψ defined in {{secure_params}} to lift Q from E' to E(GF(p^k)). Most production libraries perform this lifting implicitly by using twisted-form variants of Line_function, which are mathematically equivalent and more efficient.
 
 For BLS12_381 and BN462, Q = (x', y') is given by
 

--- a/draft-irtf-cfrg-pairing-friendly-curves.md
+++ b/draft-irtf-cfrg-pairing-friendly-curves.md
@@ -333,15 +333,15 @@ For the finite field GF(p), the towers of extension field GF(p^2), GF(p^6) and G
 
 Defined by t, the elliptic curve E and its twist E' are represented by E: y^2 = x^3 + 4 and E': y^2 = x^3 + 4(u + 1). BLS12_381 is categorized as M-type.
 
-The untwist isomorphism ψ : E'(GF(p^2)) → E(GF(p^12)) is given by
+The untwist isomorphism psi : E'(GF(p^2)) -> E(GF(p^12)) is given by
 
 ~~~~~~~~~~
 
-    ψ(x', y') = (x' / w^2, y' / w^3)
+    psi(x', y') = (x' / w^2, y' / w^3)
 
 ~~~~~~~~~~
 
-where w^2 = v ∈ GF(p^6) and v^3 = u + 1, per the tower defined in {{tower_bls12_381}}.
+where w^2 = v in GF(p^6) and v^3 = u + 1, per the tower defined in {{tower_bls12_381}}.
 
 We have to note that the security level of this pairing is expected to be 126 rather than 128 bits {{GMT19}}.
 
@@ -414,15 +414,15 @@ For the finite field GF(p), the towers of extension field GF(p^2), GF(p^6) and G
 
 Defined by t, the elliptic curve E and its twist E' are represented by E: y^2 = x^3 + 5 and E': y^2 = x^3 - u + 2, respectively. The size of p becomes 462-bit length. BN462 is categorized as D-type.
 
-The untwist isomorphism ψ : E'(GF(p^2)) → E(GF(p^12)) is given by
+The untwist isomorphism psi : E'(GF(p^2)) -> E(GF(p^12)) is given by
 
 ~~~~~~~~~~
 
-    ψ(x', y') = (x' · w^2, y' · w^3)
+    psi(x', y') = (x' * w^2, y' * w^3)
 
 ~~~~~~~~~~
 
-where w^2 = v ∈ GF(p^6) and v^3 = u + 2, per the tower defined in {{tower_bn462}}.
+where w^2 = v in GF(p^6) and v^3 = u + 2, per the tower defined in {{tower_bn462}}.
 
 We have to note that BN462 is significantly slower than BLS12_381, but has 134-bit security level {{GMT19}}, so may be more resistant to future small improvements to the exTNFS attack.
 
@@ -497,15 +497,15 @@ For the finite field GF(p), the towers of extension field GF(p^2), GF(p^4), GF(p
 
 The elliptic curve E and its twist E' are represented by E: y^2 = x^3 + 1 and E': y^2 = x^3 - 1 / w. BLS48_581 is categorized as D-type.
 
-The untwist isomorphism ψ : E'(GF(p^8)) → E(GF(p^48)) is given by
+The untwist isomorphism psi : E'(GF(p^8)) -> E(GF(p^48)) is given by
 
 ~~~~~~~~~~
 
-    ψ(x', y') = (x' · ξ^2, y' · ξ^3)
+    psi(x', y') = (x' * xi^2, y' * xi^3)
 
 ~~~~~~~~~~
 
-where ξ = u · s ∈ GF(p^48) satisfies ξ^6 = -w (the twist coefficient), per the tower defined in {{tower_bls48_581}}. Concretely: u ∈ GF(p^2) satisfies u^2 = -1, so u^6 = -1; s ∈ GF(p^48) satisfies s^2 = -z and z^3 = -w, so s^6 = w; hence ξ^6 = u^6 · s^6 = (-1) · w = -w.
+where xi = u * s in GF(p^48) satisfies xi^6 = -w (the twist coefficient), per the tower defined in {{tower_bls48_581}}. Concretely: u in GF(p^2) satisfies u^2 = -1, so u^6 = -1; s in GF(p^48) satisfies s^2 = -z and z^3 = -w, so s^6 = w; hence xi^6 = u^6 * s^6 = (-1) * w = -w.
 
 We then give the parameters for BLS48_581 as follows.
 
@@ -1600,7 +1600,7 @@ The following algorithm shows the computation of the optimal Ate pairing on Barr
 
 We provide test vectors for Optimal Ate Pairing e(P, Q) given in {{comp_pairing}} for the curves BLS12_381, BN462 and BLS48_581 given in {{secure_params}}. Here, the inputs P = (x, y) and Q = (x', y') are the corresponding base points BP and BP' given in {{secure_params}}.
 
-Note: The G_2 base points Q = (x', y') in this appendix are given in twisted form, i.e., as coordinates over E'(GF(p^(k/d))), which gives a compact representation. The pseudocode in Appendix A operates on points of the untwisted curve E(GF(p^k)). Implementations invoking that pseudocode directly must first apply the untwist isomorphism ψ defined in {{secure_params}} to lift Q from E' to E(GF(p^k)). Most production libraries perform this lifting implicitly by using twisted-form variants of Line_function, which are mathematically equivalent and more efficient.
+Note: The G_2 base points Q = (x', y') in this appendix are given in twisted form, i.e., as coordinates over E'(GF(p^(k/d))), which gives a compact representation. The pseudocode in Appendix A operates on points of the untwisted curve E(GF(p^k)). Implementations invoking that pseudocode directly must first apply the untwist isomorphism psi defined in {{secure_params}} to lift Q from E' to E(GF(p^k)). Most production libraries perform this lifting implicitly by using twisted-form variants of Line_function, which are mathematically equivalent and more efficient.
 
 For BLS12_381 and BN462, Q = (x', y') is given by
 

--- a/draft-irtf-cfrg-pairing-friendly-curves.md
+++ b/draft-irtf-cfrg-pairing-friendly-curves.md
@@ -1,6 +1,6 @@
 ---
 title: "Pairing-Friendly Curves"
-docname: draft-irtf-cfrg-pairing-friendly-curves-13
+docname: draft-irtf-cfrg-pairing-friendly-curves-latest
 category: info
 ipr: trust200902
 area: IRTF
@@ -321,6 +321,7 @@ The BLS12_381 curve is shown in {{BLS12_381}} and it is defined by the parameter
 
 where the size of p becomes 381-bit length.
 
+{: #tower_bls12_381}
 For the finite field GF(p), the towers of extension field GF(p^2), GF(p^6) and GF(p^12) are defined by indeterminates u, v, and w as follows:
 
 ~~~~~~~~~~
@@ -402,6 +403,7 @@ A BN curve with the 128-bit security level is shown in {{BD18}}, which we call B
 
 for the definition in {{BNdef}}.
 
+{: #tower_bn462}
 For the finite field GF(p), the towers of extension field GF(p^2), GF(p^6) and GF(p^12) are defined by indeterminates u, v, and w as follows:
 
 ~~~~~~~~~~
@@ -483,6 +485,7 @@ The selected BLS48 curve is shown in {{KIK17}} and it is defined by the paramete
 
 In this case, the size of p becomes 581-bit.
 
+{: #tower_bls48_581}
 For the finite field GF(p), the towers of extension field GF(p^2), GF(p^4), GF(p^8), GF(p^24) and GF(p^48) are defined by indeterminates u, v, w, z, and s as follows:
 
 ~~~~~~~~~~


### PR DESCRIPTION
## Summary

Addresses #77.

Following Emil Lundberg's feedback (CFRG mailing list, 2026-04-17), this PR adds the explicit untwist isomorphism ψ after the twist equation in each curve's section, and a clarifying note at the start of Appendix B.

### Changes

**Section 4.1.1 (BLS12_381, M-type)**
```
ψ(x', y') = (x' / w^2, y' / w^3)
```
where w^2 = v ∈ GF(p^6) and v^3 = u + 1.

**Section 4.2.1 (BN462, D-type)**
```
ψ(x', y') = (x' · w^2, y' · w^3)
```
where w^2 = v ∈ GF(p^6) and v^3 = u + 2.

**Section 4.3 (BLS48_581, D-type)**
```
ψ(x', y') = (x' · ξ^2, y' · ξ^3),  ξ = u · s
```
with ξ^6 = -w (the twist coefficient). Derivation included inline.

**Appendix B (intro)**
Added a note clarifying that G_2 base points are given in twisted form, and pointing to ψ for implementations that need the untwisted form.

### Verification

All three ψ formulas verified independently by direct curve equation substitution (not via bilinearity):
- BLS12_381: Y² = X³ + 4 in GF(p^12) ✓, r·Q = O ✓
- BN462: Y² = X³ + 5 in GF(p^12) ✓, r·Q = O ✓
- BLS48_581: Y² = X³ + 1 in GF(p^48) ✓, r·Q = O ✓

### Scope

- No change to pseudocode in Appendix A
- No change to test vector values
- Normative editorial only