### PR TITLE
Clarify in Line_function definition that coordinates are untwisted

### DIFF
--- a/draft-irtf-cfrg-pairing-friendly-curves.md
+++ b/draft-irtf-cfrg-pairing-friendly-curves.md
@@ -1822,7 +1822,7 @@ The following algorithm, Line_Function shows the computation of the line functio
 
 ~~~~~~~~~~
 
-When implementing the line function, implementers should consider the isomorphism of E and its twist curve E' so that one can reduce the computational cost of operations in G_2 {{CLN09}}{{KIK17}}. We note that Line_function does not consider such an isomorphism.
+When implementing the line function, implementers should consider the isomorphism of E and its twist curve E' so that one can reduce the computational cost of operations in G_2 {{CLN09}}{{KIK17}}. We note that Line_function does not consider such an isomorphism; i.e., the above pseudocode operates on coordinates in untwisted form.
 
 The computation of the optimal Ate pairing uses the Frobenius endomorphism. The p-power Frobenius endomorphism pi for a point Q = (x, y) over E' is pi(p, Q) = (x^p, y^p).
 


### PR DESCRIPTION
This clarification is already present in [Appendix C](https://www.ietf.org/archive/id/draft-irtf-cfrg-pairing-friendly-curves-13.html#name-test-vectors-of-optimal-ate), which is good, but this PR also adds it to the section that defines Line_function.

This is only a suggestion - you are welcome to ignore/reject this if you disagree, or to pick out any pieces you like and edit them as you please.